### PR TITLE
fix: 最後まで中央が隠れるように修正

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,8 @@ function backgroundImg(value) {
   const backElements = document.getElementsByClassName("backgroundWrapper");
   const num = 100 - value;
   for (let element of backElements) {
-    element.style.width = `${num}%`;
+    element.style.width = `${num}vw`;
+    element.style.translate = `-${value/2}vw`;
   }
 }
 

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -17,7 +17,7 @@ body {
   grid-template-columns: repeat(2, 1fr);
   grid-template-rows: repeat(2, 1fr);
   height: 100vh; /* 画面の高さに合わせる */
-  justify-items: center; /* アイテムを中央に配置 */
+  place-items: center;
 }
 .icon {
   position: relative;


### PR DESCRIPTION
## やったこと
- 現在のクリア状況に応じて画像を隠す要素を移動させるようにした
- それぞれのクイズに遷移する要素を中央に寄せた

## やっていないこと
- なし

## 画面のスクショ
<img width="1680" alt="image" src="https://github.com/kanakanho/2024ProjectExercises1TeamC/assets/76000830/10556605-4d8d-45e2-970a-10fc353579a3">
